### PR TITLE
Update zig.mod

### DIFF
--- a/zig.mod
+++ b/zig.mod
@@ -1,16 +1,9 @@
 id: w8ivwsgzl2vwyt7s7jl07x90t20ew5uct0jxuo2q90unf1j6
 name: zCord
 main: src/main.zig
+license: MIT
+description: Zig ⚡ Discord API with zero allocations in the critical path
 dependencies:
-
   - src: git https://github.com/truemedian/wz
-    name: wz
-    main: src/main.zig
-
   - src: git https://github.com/truemedian/hzzp
-    name: hzzp
-    main: src/main.zig
-
-  - src: git https://github.com/fengb/iguanaTLS
-    name: iguanaTLS
-    main: src/main.zig
+  - src: git https://github.com/alexnask/iguanaTLS


### PR DESCRIPTION
This also switches the `iguanaTLS` implementation from https://github.com/fengb/iguanaTLS to https://github.com/alexnask/iguanaTLS ensure zCord also works on the latest master and unifies the dependency with the definition in `gyro.zzz`.